### PR TITLE
Remove proxyquire in favor of directly overriding the require cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
   },
   "homepage": "https://github.com/mfowlewebs/sails-proxywrap#readme",
   "dependencies": {
-    "findhit-proxywrap": "^0.3.11",
-    "proxyquire": "^1.7.9"
+    "findhit-proxywrap": "^0.3.11"
   },
   "peerDependencies": {
     "sails": ">=0.10.0"

--- a/sails-proxywrap.js
+++ b/sails-proxywrap.js
@@ -1,7 +1,8 @@
 "use strict"
-var proxyquire = require("proxyquire"), proxywraphttp = require("./proxywraphttp"), proxywraphttps = require("./proxywraphttps")
+var proxywraphttp = require("./proxywraphttp"), proxywraphttps = require("./proxywraphttps")
 
-module.exports = proxyquire("sails",  {
-	"http": proxywraphttp,
-	"https": proxywraphttps
-})
+require.cache[require.resolve('http')] = { exports: proxywraphttp }
+require.cache[require.resolve('https')] = { exports: proxywraphttps }
+
+module.exports = require("sails")
+


### PR DESCRIPTION
http and https are nested runtime dependencies of sails. Due to this,
proxyquire can only work if you set the @runtimeGlobal flag, which has
an existing issue with circular dependencies.

Directly overriding the require cache to inject the proxywrap versions
of http and http achieves the desired effect.
