### PR TITLE
Allow user to provide findhit-proxywrap options to sails-proxywrap

### DIFF
--- a/proxywraphttp.js
+++ b/proxywraphttp.js
@@ -1,4 +1,6 @@
 "use strict"
 var http = require("http"), proxywrap = require("findhit-proxywrap")
 
-module.exports = proxywrap.proxy(http)
+module.exports = function proxywrapHttp(options) {
+	return proxywrap.proxy(http, options)
+}

--- a/proxywraphttps.js
+++ b/proxywraphttps.js
@@ -1,4 +1,6 @@
 "use strict"
 var https = require("https"), proxywrap = require("findhit-proxywrap")
 
-module.exports = proxywrap.proxy(https)
+module.exports = function proxywrapHttps(options) {
+	return proxywrap.proxy(https, options)
+}

--- a/sails-proxywrap.js
+++ b/sails-proxywrap.js
@@ -1,8 +1,15 @@
 "use strict"
-var proxywraphttp = require("./proxywraphttp"), proxywraphttps = require("./proxywraphttps")
+var proxywraphttp, proxywraphttps
 
-require.cache[require.resolve('http')] = { exports: proxywraphttp }
-require.cache[require.resolve('https')] = { exports: proxywraphttps }
+module.exports = function proxywrapSails(options) {
+	options = Object.assign({}, options);
 
-module.exports = require("sails")
+	proxywraphttp = require("./proxywraphttp")(options)
+	proxywraphttps = require("./proxywraphttps")(options)
+
+	require.cache[require.resolve('http')] = { exports: proxywraphttp }
+	require.cache[require.resolve('https')] = { exports: proxywraphttps }
+
+	return require('sails');
+}
 


### PR DESCRIPTION
`findhit-proxywrap`'s [`.proxy()`](https://github.com/findhit/proxywrap#proxyserver-options) method allows the user to provide an options object which impacts how the proxy-enabled http(s) server handles requests. Of particular benefit is the `strict` option which will [determine whether the wrapped server allows or disallows incoming connections without a `PROXY PROTOCOL` header](https://github.com/findhit/proxywrap/blob/master/lib/proxywrap.js#L226).

This pull request changes the contract of `sails-proxywrap` to no longer return `sails`, but rather a function which the user can then provide `findhit-proxywrap` options to. 

Current contract:

```
var sails = require('sails-proxywrap');
```

Proposed contract:

```
var sails = require('sails-proxywrap')(options);
```

This would represent a breaking change for `sails-proxywrap`, but a change that would allow `sails-proxywrap` consumers to configure their wrapped version of `sails`.
